### PR TITLE
Update to getTypeSchema() to generate on the fly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Builds platform design information packages.
   data such as x, y position on chip and
   featureSet ID. The database also incorporates featureSet-level
   annotation data. The products of this packages are used by the oligo pkg.
-Version: 1.33.0
+Version: 1.33.1
 Author: Seth Falcon, Vince Carey, Matt Settles, Kristof de Beuf, Benilton Carvalho
 Maintainer: Benilton Carvalho <beniltoncarvalho@gmail.com>
 LazyLoad: yes

--- a/R/pdBuilderV2ExonTranscription.R
+++ b/R/pdBuilderV2ExonTranscription.R
@@ -177,7 +177,8 @@ parseProbesetCSV <- function(probeFile, verbose=TRUE){
 ##
 
   ## type_schema
-  type_schema <- getTypeSchema()
+  ##type_schema <- getTypeSchema()
+  ## do this on the fly, below
 ##   type_schema <- data.frame(type=as.integer(1:8),
 ##                             type_id=c("main", "control->affx",
 ##                                       "control->chip",
@@ -203,6 +204,10 @@ parseProbesetCSV <- function(probeFile, verbose=TRUE){
   cols[1] <- "fsetid"
   names(probesets) <- cols
   rm(cols)
+
+  ## type_schema
+  type_schema <- getTypeSchema(probesets)
+               
 
   chromosome_schema <- createChrDict(probesets[["seqname"]])
 

--- a/R/pdBuilderV2HTA2.R
+++ b/R/pdBuilderV2HTA2.R
@@ -50,8 +50,8 @@ parseHtaProbesetCSV <- function(probeFile, verbose=TRUE){
   level_schema <- getLevelSchema()
 
   ## type_schema
-  type_schema <- getTypeSchema()
-
+  ## type_schema <- getTypeSchema()
+  ## do this on the fly, below
   if (verbose) msgOK()
 
 
@@ -73,6 +73,9 @@ parseHtaProbesetCSV <- function(probeFile, verbose=TRUE){
   names(probesets) <- cols
   rm(cols)
 ##  probesets$fsetid <- as.integer(factor(probesets$man_fsetid))
+
+  ## type_schema
+  type_schema <- getTypeSchema(probesets)
 
   chromosome_schema <- createChrDict(probesets[["seqname"]])
 

--- a/R/pdBuilderV2miRNA.R
+++ b/R/pdBuilderV2miRNA.R
@@ -8,18 +8,13 @@ miRNAFeatureSetSchema <- list(col2type=c(
                               ))
 
 
-getTypeSchema <- function()
-    data.frame(type=as.integer(1:17),
-               type_id=c("main","main->junctions", "main->psrs",
-                   "main->rescue",  "control->affx", "control->chip",
-                   "control->bgp->antigenomic",
-                   "control->bgp->genomic", "normgene->exon",
-                   "normgene->intron", "rescue->FLmRNA->unmapped",
-                   "control->affx->bac_spike", "oligo_spike_in",
-                   "r1_bac_spike_at", "control->affx->polya_spike",
-                   "control->affx->ercc",
-                   "control->affx->ercc->step"),
-               stringsAsFactors=FALSE)
+getTypeSchema <- function(probesets) {
+     tab <- table(probesets[["probeset_type"]])
+     mainloc <- grep("main", names(tab))
+     data.frame(type = seq_len(length(tab)),
+                type_id = names(tab)[c(mainloc, seq_len(length(tab))[-mainloc])],
+                stringsAsFactors = FALSE)
+ }
 
 getLevelSchema <- function()
     data.frame(level=as.integer(1:5),


### PR DESCRIPTION
The hard coded type_schema is problematic because Affy keeps adding new types, or makes slight changes to existing types (reporter gets changed to Reporter, because of course). Instead, it is preferable to generate a type_schema on the fly, based on what is on the array.

This still doesn't account for the probesets that do double-duty as main probesets as well as normgene->exon probesets, but I don't know a good way to handle those yet. Here is what I get from a pd.hugene.2.0.st package generated with the updated code:

> con <- db(pd.hugene.2.0.st)
> dbGetQuery(con, "select * from type_dict;")
  type                    type_id
1    1                       main
2    2              control->affx
3    3   control->affx->bac_spike
4    4        control->affx->ercc
5    5 control->affx->polya_spike
6    6  control->bgp->antigenomic
7    7           normgene->intron
8    8                   Reporter
9    9                     rescue
> table(dbGetQuery(con, "select distinct meta_fsetid, type from featureSet inner join core_mps using(fsetid);")[,2])

    1     2     3     4     5     6     7     8     9 
46255    18    18    92    39    23  3575    82  3515 
> load(paste0(path.package("pd.hugene.2.0.st"), "/extdata/netaffxTranscript.rda"))
> table(pData(netaffxTranscript)$category)

             control->affx   control->affx->bac_spike 
                        18                         18 
       control->affx->ercc control->affx->polya_spike 
                        92                         39 
 control->bgp->antigenomic                       main 
                        23                      44629 
            normgene->exon           normgene->intron 
                      1626                       3575 
                  reporter                     rescue 
                        82                       3515 

Note that the featureSet considers the 1626 normgene->exon probesets to be 'main' probesets. This is because they ARE main probesets when summarized at the 'probeset' level, but when summarized at the 'core' level, they are considered normgene->exon.

